### PR TITLE
[Breaking Change] Use registerDocumentRangeFormattingEditProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,10 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+- Removed `Prettier` action.
+- Use vscode actions `Format Document` and `Format Selection`.
+- Removed `prettier.formatOnSave` setting in favor of the more general setting `editor.formatOnSave` 
+- Deprecated `useFlowParser` setting. Introduced `parser` setting. (Since prettier 0.0.10)
+
+## [0.1.0]
 - Initial release

--- a/README.md
+++ b/README.md
@@ -19,19 +19,17 @@ ext install prettier-vscode
 #### Using Command Palette (CMD + Shift + P)
 
 ```
+1. CMD + Shift + P -> Format Document
+OR
 1. Select the text you want to Prettify
-2. CMD + Shift + P -> Prettier
+2. CMD + Shift + P -> Format Selection
 ```
 
 #### Format On Save
 
-Automatically format your Javascript file on save by enabling the *Format On Save* package setting.  This is off by default.
+Respects `editor.formatOnSave` setting.
 
 ### Settings
-
-#### formatOnSave (default: false)
-
-Format Javascript files when saving.
 
 #### printWidth (default: 80)
 
@@ -42,7 +40,7 @@ Fit code within this line limit
 Number of spaces it should use per tab
 
 #### useFlowParser (default: false)
-Use the flow parser instead of babylon
+Use the flow parser instead of babylon. **Deprecated** use `parser: 'flow'` instead
 
 #### singleQuote (default: false)
 If true, will use single instead of double quotes
@@ -53,6 +51,8 @@ Controls the printing of trailing commas wherever possible
 #### bracketSpacing (default: true)
 Controls the printing of spaces inside array and objects
 
+#### parser (default: 'babylon')
+Which parser to use. Valid options are 'flow' and 'babylon'
 
 ### Contribute
 

--- a/package.json
+++ b/package.json
@@ -31,21 +31,10 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
-    "commands": [
-      {
-        "command": "prettier.format",
-        "title": "Prettier: Format Javascript"
-      }
-    ],
     "configuration": {
         "type": "object",
         "title": "Prettier - JavaScript formatter configuration",
         "properties": {
-            "prettier.formatOnSave": {
-                "type": "boolean",
-                "default": false,
-                "description": "Format on save"
-            },
             "prettier.printWidth": {
                 "type": "integer",
                 "default": 80,

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   ],
   "activationEvents": [
     "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onCommand:prettier.format"
+    "onLanguage:javascriptreact"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "homepage": "https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/esbenp/prettier-vscode.git"
+    "type": "git",
+    "url": "https://github.com/esbenp/prettier-vscode.git"
   },
   "license": "MIT",
   "bugs": {
-      "url": "https://github.com/esbenp/prettier-vscode/issues"
+    "url": "https://github.com/esbenp/prettier-vscode/issues"
   },
   "engines": {
     "vscode": "^1.5.0"
@@ -32,40 +32,49 @@
   "main": "./out/src/extension",
   "contributes": {
     "configuration": {
-        "type": "object",
-        "title": "Prettier - JavaScript formatter configuration",
-        "properties": {
-            "prettier.printWidth": {
-                "type": "integer",
-                "default": 80,
-                "description": "Fit code within this line limit"
-            },
-            "prettier.tabWidth": {
-                "type": "integer",
-                "default": 2,
-                "description": "Number of spaces it should use per tab"
-            },
-            "prettier.useFlowParser": {
-                "type": "boolean",
-                "default": false,
-                "description": "Use the flow parser instead of babylon"
-            },
-            "prettier.singleQuote": {
-                "type": "boolean",
-                "default": false,
-                "description": "If true, will use single instead of double quotes"
-            },
-            "prettier.trailingComma": {
-                "type": "boolean",
-                "default": false,
-                "description": "Controls the printing of trailing commas wherever possible"
-            },
-            "prettier.bracketSpacing": {
-                "type": "boolean",
-                "default": true,
-                "description": "Controls the printing of spaces inside array and objects"
-            }
+      "type": "object",
+      "title": "Prettier - JavaScript formatter configuration",
+      "properties": {
+        "prettier.printWidth": {
+          "type": "integer",
+          "default": 80,
+          "description": "Fit code within this line limit"
+        },
+        "prettier.tabWidth": {
+          "type": "integer",
+          "default": 2,
+          "description": "Number of spaces it should use per tab"
+        },
+        "prettier.useFlowParser": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use the flow parser instead of babylon (deprecated, use 'parser:\"babylon\"' instead)"
+        },
+        "prettier.singleQuote": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, will use single instead of double quotes"
+        },
+        "prettier.trailingComma": {
+          "type": "boolean",
+          "default": false,
+          "description": "Controls the printing of trailing commas wherever possible"
+        },
+        "prettier.bracketSpacing": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls the printing of spaces inside array and objects"
+        },
+        "prettier.parser": {
+          "type": "string",
+          "enum": [
+            "babylon",
+            "flow"
+          ],
+          "default": "babylon",
+          "description": "Which parser to use. Valid options are 'flow' and 'babylon'"
         }
+      }
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "activationEvents": [
     "onLanguage:javascript",
+    "onLanguage:javascriptreact",
     "onCommand:prettier.format"
   ],
   "main": "./out/src/extension",

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -1,6 +1,7 @@
 import {
     workspace,
     DocumentRangeFormattingEditProvider,
+    DocumentFormattingEditProvider,
     Range,
     TextDocument,
     FormattingOptions,
@@ -40,11 +41,19 @@ function format(text: string): string {
             parser: parser
         });
     } catch (e) {
-        console.log("Error transforming using prettier:", e);
+        console.log("Error transforming using prettier:", e.message);
         return text;
     }
 }
-class PrettierEditProvider implements DocumentRangeFormattingEditProvider {
+
+function fullDocumentRange(document: TextDocument): Range {
+    const lastLineId = document.lineCount - 1;
+    return new Range(0, 0, lastLineId, document.lineAt(lastLineId).text.length);
+}
+
+class PrettierEditProvider implements
+    DocumentRangeFormattingEditProvider,
+    DocumentFormattingEditProvider {
     provideDocumentRangeFormattingEdits(
         document: TextDocument,
         range: Range,
@@ -53,7 +62,14 @@ class PrettierEditProvider implements DocumentRangeFormattingEditProvider {
     ): TextEdit[] {
         return [TextEdit.replace(range, format(document.getText(range)))];
     }
+    provideDocumentFormattingEdits(
+        document: TextDocument,
+        options: FormattingOptions,
+        token: CancellationToken
+    ): TextEdit[] {
+        return [TextEdit.replace(fullDocumentRange(document), format(document.getText()))];
+    }
 }
 
 export default PrettierEditProvider;
-export {PrettierConfig}
+export { PrettierConfig }

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -49,4 +49,4 @@ class PrettierEditProvider implements DocumentRangeFormattingEditProvider {
 }
 
 export default PrettierEditProvider;
-export { PrettierConfig, format };
+export {PrettierConfig}

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -34,7 +34,6 @@ function format(text: string): string {
         return prettier.format(text, {
             printWidth: config.printWidth,
             tabWidth: config.tabWidth,
-            useFlowParser: config.useFlowParser,
             singleQuote: config.singleQuote,
             trailingComma: config.trailingComma,
             bracketSpacing: config.bracketSpacing,

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -1,0 +1,52 @@
+import {
+    workspace,
+    DocumentRangeFormattingEditProvider,
+    Range,
+    TextDocument,
+    FormattingOptions,
+    CancellationToken,
+    TextEdit
+} from 'vscode';
+
+const prettier = require('prettier');
+
+interface PrettierConfig {
+    printWidth: number,
+    tabWidth: number,
+    useFlowParser: boolean,
+    singleQuote: boolean,
+    trailingComma: boolean,
+    bracketSpacing: boolean,
+    formatOnSave: boolean
+}
+
+function format(text: string): string {
+    const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
+    let transformed: string;
+    try {
+        return prettier.format(text, {
+            printWidth: config.printWidth,
+            tabWidth: config.tabWidth,
+            useFlowParser: config.useFlowParser,
+            singleQuote: config.singleQuote,
+            trailingComma: config.trailingComma,
+            bracketSpacing: config.bracketSpacing
+        });
+    } catch (e) {
+        console.log("Error transforming using prettier:", e);
+        return text;
+    }
+}
+class PrettierEditProvider implements DocumentRangeFormattingEditProvider {
+    provideDocumentRangeFormattingEdits(
+        document: TextDocument,
+        range: Range,
+        options: FormattingOptions,
+        token: CancellationToken
+    ): TextEdit[] {
+        return [TextEdit.replace(range, format(document.getText(range)))];
+    }
+}
+
+export default PrettierEditProvider;
+export { PrettierConfig, format };

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -13,15 +13,22 @@ const prettier = require('prettier');
 interface PrettierConfig {
     printWidth: number,
     tabWidth: number,
-    useFlowParser: boolean,
+    useFlowParser: boolean, // deprecated
     singleQuote: boolean,
     trailingComma: boolean,
     bracketSpacing: boolean,
-    formatOnSave: boolean
+    parser: string
 }
 
 function format(text: string): string {
     const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
+    /*
+    handle deprecated parser option
+    */
+    let parser = config.parser;
+    if (!parser) { // unset config
+        parser = config.useFlowParser ? 'flow' : 'babylon';
+    }
     let transformed: string;
     try {
         return prettier.format(text, {
@@ -30,7 +37,8 @@ function format(text: string): string {
             useFlowParser: config.useFlowParser,
             singleQuote: config.singleQuote,
             trailingComma: config.trailingComma,
-            bracketSpacing: config.bracketSpacing
+            bracketSpacing: config.bracketSpacing,
+            parser: parser
         });
     } catch (e) {
         console.log("Error transforming using prettier:", e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,27 +1,22 @@
-'use strict';
+import {
+    commands,
+    languages,
+    ExtensionContext,
+    DocumentSelector,
+    Range,
+    Position,
+    TextEdit,
+    TextDocument,
+    window,
+    workspace
+} from 'vscode';
+import EditProvider, { format, PrettierConfig } from './PrettierEditProvider';
 
-import { commands, ExtensionContext, Range, Position, TextEdit, window, workspace } from 'vscode';
-const prettier = require('prettier')
-
-interface PrettierConfig {
-    printWidth: number,
-    tabWidth: number,
-    useFlowParser: boolean,
-    singleQuote: boolean,
-    trailingComma: boolean,
-    bracketSpacing: boolean,
-    formatOnSave: boolean
-}
-
-interface Rangeable {
-    end: Position,
-    isEmpty: boolean,
-    start: Position
-}
+const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact'];
 
 export function activate(context: ExtensionContext) {
     const eventDisposable = (workspace as any).onWillSaveTextDocument(e => {
-        const document = e.document;
+        const document: TextDocument = e.document;
 
         if (!document.isDirty) {
             return;
@@ -34,7 +29,7 @@ export function activate(context: ExtensionContext) {
         }
 
         e.waitUntil(new Promise(resolve => {
-            const prettified = format(document, null);
+            const prettified = format(document.getText());
             const rangeObj = createFullDocumentRange(document)
             const edit = TextEdit.replace(rangeObj, prettified);
 
@@ -50,12 +45,12 @@ export function activate(context: ExtensionContext) {
 
         const document = editor.document
 
-        let selectionOrRange : Rangeable = editor.selection;
+        let selectionOrRange: Range = editor.selection;
         if (selectionOrRange.isEmpty) {
             selectionOrRange = createFullDocumentRange(document)
         }
 
-        const prettified = format(document, selectionOrRange);
+        const prettified = format(document.getText(selectionOrRange));
 
         editor.edit((editBuilder) => {
             const rangeObj = new Range(
@@ -69,6 +64,7 @@ export function activate(context: ExtensionContext) {
     });
     context.subscriptions.push(eventDisposable);
     context.subscriptions.push(disposable);
+    context.subscriptions.push(languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, new EditProvider()));
 }
 
 // this method is called when your extension is deactivated
@@ -76,24 +72,3 @@ export function deactivate() {
 }
 
 const createFullDocumentRange = document => new Range(0, 0, document.lineCount, 0)
-
-const format = (document, selection = null) => {
-    const text = document.getText(selection)
-    const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
-
-    try {
-        var transformed = prettier.format(text, {
-            printWidth: config.printWidth,
-            tabWidth: config.tabWidth,
-            useFlowParser: config.useFlowParser,
-            singleQuote: config.singleQuote,
-            trailingComma: config.trailingComma,
-            bracketSpacing: config.bracketSpacing
-        });
-    } catch (e) {
-        console.log("Error transforming using prettier:", e);
-        transformed = text;
-    }
-
-    return transformed
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,10 @@ import EditProvider, { PrettierConfig } from './PrettierEditProvider';
 const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact'];
 
 export function activate(context: ExtensionContext) {
+    const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
+    if(config.useFlowParser){
+        window.showWarningMessage("Option 'useFlowParser' has been deprecated. Use 'parser: \"flow\"' instead.")
+    }
     context.subscriptions.push(
         languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, new EditProvider())
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,11 +11,15 @@ const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact'];
 
 export function activate(context: ExtensionContext) {
     const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
-    if(config.useFlowParser){
+    const editProvider = new EditProvider()
+    if (config.useFlowParser) {
         window.showWarningMessage("Option 'useFlowParser' has been deprecated. Use 'parser: \"flow\"' instead.")
     }
     context.subscriptions.push(
-        languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, new EditProvider())
+        languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, editProvider)
+    );
+    context.subscriptions.push(
+        languages.registerDocumentFormattingEditProvider(VALID_LANG, editProvider)
     );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,74 +1,20 @@
 import {
-    commands,
     languages,
     ExtensionContext,
     DocumentSelector,
-    Range,
-    Position,
-    TextEdit,
-    TextDocument,
     window,
     workspace
 } from 'vscode';
-import EditProvider, { format, PrettierConfig } from './PrettierEditProvider';
+import EditProvider, { PrettierConfig } from './PrettierEditProvider';
 
 const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact'];
 
 export function activate(context: ExtensionContext) {
-    const eventDisposable = (workspace as any).onWillSaveTextDocument(e => {
-        const document: TextDocument = e.document;
-
-        if (!document.isDirty) {
-            return;
-        }
-
-        const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
-        const formatOnSave = config.formatOnSave;
-        if (!formatOnSave) {
-            return;
-        }
-
-        e.waitUntil(new Promise(resolve => {
-            const prettified = format(document.getText());
-            const rangeObj = createFullDocumentRange(document)
-            const edit = TextEdit.replace(rangeObj, prettified);
-
-            resolve([edit]);
-        }))
-    });
-
-    const disposable = commands.registerCommand('prettier.format', () => {
-        let editor = window.activeTextEditor;
-        if (!editor) {
-            return;
-        }
-
-        const document = editor.document
-
-        let selectionOrRange: Range = editor.selection;
-        if (selectionOrRange.isEmpty) {
-            selectionOrRange = createFullDocumentRange(document)
-        }
-
-        const prettified = format(document.getText(selectionOrRange));
-
-        editor.edit((editBuilder) => {
-            const rangeObj = new Range(
-                selectionOrRange.start.line,
-                selectionOrRange.start.character,
-                selectionOrRange.end.line,
-                selectionOrRange.end.character
-            );
-            editBuilder.replace(rangeObj, prettified);
-        })
-    });
-    context.subscriptions.push(eventDisposable);
-    context.subscriptions.push(disposable);
-    context.subscriptions.push(languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, new EditProvider()));
+    context.subscriptions.push(
+        languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, new EditProvider())
+    );
 }
 
 // this method is called when your extension is deactivated
 export function deactivate() {
 }
-
-const createFullDocumentRange = document => new Range(0, 0, document.lineCount, 0)


### PR DESCRIPTION
This uses vscode's formatter API `languages.registerDocumentRangeFormattingEditProvider`.
It replaces vscode's JavaScript formatter with prettier.

➕  Less options/keybindings required.

➖  The original formatter is no more accessible if you still want it.

It will run on following [commands](https://code.visualstudio.com/docs/customization/keybindings#_rich-languages-editing):
- `editor.action.formatDocument` (default key: `Shift+Alt+F`)
- `editor.action.formatSelection` (default key: `Ctrl+K Ctrl+F`)
- if `editor.formatOnSave` is enabled

Added javascriptreact lang support

The original code was not removed, I think a discussion is clearly needed as it would be a **breaking change**.

So choices with this PR are:
 - extension command (`prettier.format`) (reject this PR)
 - formatter API (I update this PR: remove command)
 - Both, IMO a bad option... (_this_)

Note: Missing an updated readme