### PR TITLE
Add key binding rule to prettify focused text

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
         "title": "Prettier: Format Javascript"
       }
     ],
+    "keybindings": [{
+      "command": "prettier.format",
+      "key": "ctrl+p",
+      "mac": "cmd+p",
+      "when": "editorTextFocus"
+    }], 
     "configuration": {
         "type": "object",
         "title": "Prettier - JavaScript formatter configuration",


### PR DESCRIPTION
This contributes to #11 partially by defining a key binding for prettifying depending on the editor's focused text.