### PR TITLE
Make formatOnSave work only in javascript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "url": "https://github.com/esbenp/prettier-vscode/issues"
   },
   "engines": {
-    "vscode": "^1.5.0"
+    "vscode": "^1.8.0"
   },
   "categories": [
     "Formatters"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,12 +20,16 @@ interface Rangeable {
 }
 
 export function activate(context: ExtensionContext) {
-    const eventDisposable = (workspace as any).onWillSaveTextDocument(e => {
+    const eventDisposable = workspace.onWillSaveTextDocument(e => {
         const document = e.document;
 
         if (!document.isDirty) {
             return;
         }
+
+        if (document.languageId !== 'javascript') {
+            return;
+        };
 
         const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
         const formatOnSave = config.formatOnSave;


### PR DESCRIPTION
Currently, if `formatOnSave` is `true`, this plugin tries to format every file (.travis.yml, for instance).
This solves this problem.

Although #18 looks better for this sort of plugin, IMHO...