### PR TITLE
Show error message to user

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -1,19 +1,22 @@
 import {
     workspace,
+    window,
     DocumentRangeFormattingEditProvider,
     DocumentFormattingEditProvider,
     Range,
     TextDocument,
     FormattingOptions,
     CancellationToken,
-    TextEdit
+    TextEdit,
+    Selection,
+    Position
 } from 'vscode';
 
 const prettier = require('prettier');
 
 type ParserOption = 'babylon' | 'flow'
 type TrailingCommaOption = 'none' | 'es5' | 'all' | boolean /* deprecated boolean*/
-
+type ShowAction = "Show";
 interface PrettierConfig {
     printWidth: number,
     tabWidth: number,
@@ -24,7 +27,10 @@ interface PrettierConfig {
     jsxBracketSameLine: boolean,
     parser: ParserOption
 }
-
+/**
+ * Format the given text with prettier with user's configuration.
+ * @param text Text to format
+ */
 function format(text: string): string {
     const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
     /*
@@ -43,21 +49,15 @@ function format(text: string): string {
     } else if (trailingComma === false) {
         trailingComma = 'none';
     }
-    let transformed: string;
-    try {
-        return prettier.format(text, {
-            printWidth: config.printWidth,
-            tabWidth: config.tabWidth,
-            singleQuote: config.singleQuote,
-            trailingComma,
-            bracketSpacing: config.bracketSpacing,
-            jsxBracketSameLine: config.jsxBracketSameLine,
-            parser: parser
-        });
-    } catch (e) {
-        console.log("Error transforming using prettier:", e.message);
-        return text;
-    }
+    return prettier.format(text, {
+        printWidth: config.printWidth,
+        tabWidth: config.tabWidth,
+        singleQuote: config.singleQuote,
+        trailingComma,
+        bracketSpacing: config.bracketSpacing,
+        jsxBracketSameLine: config.jsxBracketSameLine,
+        parser: parser
+    });
 }
 
 function fullDocumentRange(document: TextDocument): Range {
@@ -74,16 +74,67 @@ class PrettierEditProvider implements
         options: FormattingOptions,
         token: CancellationToken
     ): TextEdit[] {
-        return [TextEdit.replace(range, format(document.getText(range)))];
+        try {
+            return [TextEdit.replace(range, format(document.getText(range)))];
+        } catch (e) {
+            let errorPosition
+            if (e.loc) {
+                let charPos = e.loc.column;
+                if (e.loc.line === 1) { // start selection range
+                    charPos = range.start.character + e.loc.column;
+                }
+                errorPosition = new Position(e.loc.line - 1 + range.start.line, charPos);
+            }
+            handleError(document, e.message, errorPosition);
+        }
     }
     provideDocumentFormattingEdits(
         document: TextDocument,
         options: FormattingOptions,
         token: CancellationToken
     ): TextEdit[] {
-        return [TextEdit.replace(fullDocumentRange(document), format(document.getText()))];
+        try {
+            return [TextEdit.replace(fullDocumentRange(document), format(document.getText()))];
+        } catch (e) {
+            let errorPosition;
+            if (e.loc) {
+                errorPosition = new Position(e.loc.line - 1, e.loc.column);
+            }
+            handleError(document, e.message, errorPosition);
+        }
     }
 }
-
+/**
+ * Handle errors for a given text document.
+ * Steps: 
+ *  - Show the error message.
+ *  - Scroll to the error position in given document if asked for it.
+ * 
+ * @param document Document which raised the error
+ * @param message Error message
+ * @param errorPosition Position where the error occured. Relative to document.
+ */
+function handleError(document: TextDocument, message: string, errorPosition: Position) {
+    if (errorPosition) {
+        window.showErrorMessage(message, "Show").then(function onAction(action?: ShowAction) {
+            if (action === "Show") {
+                const rangeError = new Range(errorPosition, errorPosition);
+                /*
+                Show text document which has errored.
+                Format on save case. (save all)
+                */
+                window.showTextDocument(document).then(
+                    (editor) => {
+                        // move cursor to error position and show it.
+                        editor.selection = new Selection(rangeError.start, rangeError.end);
+                        editor.revealRange(rangeError);
+                    }
+                );
+            }
+        });
+    } else {
+        window.showErrorMessage(message);
+    }
+}
 export default PrettierEditProvider;
 export { PrettierConfig }


### PR DESCRIPTION
Instead of silently printing error in a console a user certainly won't
see, show an error message with an option to show it.
Scroll to and move cursor to it.

Handles multiple error in case a user saves all files.