### PR TITLE
Readme Settings update to match prettier's

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If true, will use single instead of double quotes
 Controls the printing of trailing commas wherever possible
 
 #### bracketSpacing (default: true)
-Controls the printing of spaces inside array and objects
+Controls the printing of spaces inside object literals
 
 #### parser (default: 'babylon')
 Which parser to use. Valid options are 'flow' and 'babylon'


### PR DESCRIPTION
Bracket spacing is **only** for object litterals
Pointed out in #35 