### PR TITLE
Update to prettier 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 All notable changes to the "prettier-vscode" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
 ## [Unreleased]
-- New setting `jsxBracketSameLine`.
+- New setting `jsxBracketSameLine`. (prettier 0.17.0)
+- Changed `trailingComma` setting `['none', 'es5', 'all']` (prettier 0.19.0)
 
 ## [0.7.0]
 - Removed `Prettier` action.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to the "prettier-vscode" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## [Unreleased]
+- New setting `jsxBracketSameLine`.
 
 ## [0.7.0]
 - Removed `Prettier` action.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ Use the flow parser instead of babylon. **Deprecated** use `parser: 'flow'` inst
 #### singleQuote (default: false)
 If true, will use single instead of double quotes
 
-#### trailingComma (default: false)
-Controls the printing of trailing commas wherever possible
+#### trailingComma (default: 'none')
+Controls the printing of trailing commas wherever possible. Valid options:
+ - "none" - No trailing commas
+ - "es5"  - Trailing commas where valid in ES5 (objects, arrays, etc)
+ - "all"  - Trailing commas wherever possible (function arguments)
 
 #### bracketSpacing (default: true)
 Controls the printing of spaces inside object literals

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Controls the printing of trailing commas wherever possible
 #### bracketSpacing (default: true)
 Controls the printing of spaces inside object literals
 
+#### jsxBracketSameLine (default: false)
+If true, puts the `>` of a multi-line jsx element at the end of the last line instead of being alone on the next line
+
 #### parser (default: 'babylon')
 Which parser to use. Valid options are 'flow' and 'babylon'
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "0.17.0"
+    "prettier": "0.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,13 @@
           "description": "If true, will use single instead of double quotes"
         },
         "prettier.trailingComma": {
-          "type": "boolean",
-          "default": false,
+          "type": "string",
+          "enum": [
+            "none",
+            "es5",
+            "all"
+          ],
+          "default": "none",
           "description": "Controls the printing of trailing commas wherever possible"
         },
         "prettier.bracketSpacing": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,6 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "0.20.0"
+    "prettier": "0.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "0.18.0"
+    "prettier": "0.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,12 @@
         "prettier.bracketSpacing": {
           "type": "boolean",
           "default": true,
-          "description": "Controls the printing of spaces inside array and objects"
+          "description": "Controls the printing of spaces inside object literals"
+        },
+        "prettier.jsxBracketSameLine": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, puts the `>` of a multi-line jsx element at the end of the last line instead of being alone on the next line"
         },
         "prettier.parser": {
           "type": "string",

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -18,6 +18,7 @@ interface PrettierConfig {
     singleQuote: boolean,
     trailingComma: boolean,
     bracketSpacing: boolean,
+    jsxBracketSameLine: boolean,
     parser: string
 }
 
@@ -38,6 +39,7 @@ function format(text: string): string {
             singleQuote: config.singleQuote,
             trailingComma: config.trailingComma,
             bracketSpacing: config.bracketSpacing,
+            jsxBracketSameLine: config.jsxBracketSameLine,
             parser: parser
         });
     } catch (e) {

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -11,15 +11,18 @@ import {
 
 const prettier = require('prettier');
 
+type ParserOption = 'babylon' | 'flow'
+type TrailingCommaOption = 'none' | 'es5' | 'all' | boolean /* deprecated boolean*/
+
 interface PrettierConfig {
     printWidth: number,
     tabWidth: number,
     useFlowParser: boolean, // deprecated
     singleQuote: boolean,
-    trailingComma: boolean,
+    trailingComma: TrailingCommaOption,
     bracketSpacing: boolean,
     jsxBracketSameLine: boolean,
-    parser: string
+    parser: ParserOption
 }
 
 function format(text: string): string {
@@ -31,13 +34,22 @@ function format(text: string): string {
     if (!parser) { // unset config
         parser = config.useFlowParser ? 'flow' : 'babylon';
     }
+    /*
+    handle trailingComma changes boolean -> string
+    */
+    let trailingComma = config.trailingComma;
+    if (trailingComma === true) {
+        trailingComma = 'es5';
+    } else if (trailingComma === false) {
+        trailingComma = 'none';
+    }
     let transformed: string;
     try {
         return prettier.format(text, {
             printWidth: config.printWidth,
             tabWidth: config.tabWidth,
             singleQuote: config.singleQuote,
-            trailingComma: config.trailingComma,
+            trailingComma,
             bracketSpacing: config.bracketSpacing,
             jsxBracketSameLine: config.jsxBracketSameLine,
             parser: parser

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,12 +9,19 @@ import EditProvider, { PrettierConfig } from './PrettierEditProvider';
 
 const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact'];
 
-export function activate(context: ExtensionContext) {
+function checkConfig() {
     const config: PrettierConfig = workspace.getConfiguration('prettier') as any;
-    const editProvider = new EditProvider()
     if (config.useFlowParser) {
-        window.showWarningMessage("Option 'useFlowParser' has been deprecated. Use 'parser: \"flow\"' instead.")
+        window.showWarningMessage("Option 'useFlowParser' has been deprecated. Use 'parser: \"flow\"' instead.");
     }
+    if (typeof config.trailingComma === 'boolean') {
+        window.showWarningMessage("Option 'trailingComma' as a boolean value has been deprecated. Use 'none', 'es5' or 'all' instead.");
+    }
+}
+export function activate(context: ExtensionContext) {
+    const editProvider = new EditProvider();
+    checkConfig();
+
     context.subscriptions.push(
         languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, editProvider)
     );


### PR DESCRIPTION
* Handle `jsxBracketSameLine` introduced in prettier [0.17.0 ](https://github.com/jlongster/prettier/blob/master/CHANGELOG.md#0171)
  > Add option for putting > on the last line in jsx

* Update prettier to 0.21.0

* Change `trailingComma` from boolean value to string in `['none', 'es5', 'all']`

* Correct bracket spacing description in configuration (My bad, I forget this file in #37)

collides with #45 