### PR TITLE
[WIP] Prettier require resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "prettier-vscode" extension will be documented in thi
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+- Resolve 'prettier' against formatted file. Nearest upward *node_modules/prettier*
 
 ## [0.10.0]
 - New setting `jsxBracketSameLine`. (prettier 0.17.0)

--- a/src/requirePrettier.ts
+++ b/src/requirePrettier.ts
@@ -1,0 +1,25 @@
+const path = require('path');
+const Module = require('module');
+
+interface Prettier {
+    format: (string, PrettierConfig?) => string;
+    readonly version: string;
+}
+
+/**
+ * Require 'prettier' relative to given path.
+ * Fallback to packaged one if no prettier was found bottom up.
+ * @param {string} fspath file system path starting point to resolve 'prettier'
+ * @returns {Prettier} prettier
+ */
+function requirePrettier(fspath: string): Prettier {
+    const fileModule = new Module(fspath);
+    fileModule.paths = Module._nodeModulePaths(path.join(fspath, '..'));
+    try {
+        return fileModule.require('prettier');
+    } catch (e) {
+        // No local prettier found
+    }
+    return require('prettier');
+}
+export default requirePrettier;


### PR DESCRIPTION
Will resolve prettier in the following order
 1. local resolution
 1. ~~global resolution~~ *postponed*
 1. package resolution

Progress:
- [x]  require local 
- [x] require packaged

Other:
- [x] Changelog
- [ ] Readme

fixes #29 

~~Currently I'm waiting for a [response](https://github.com/esbenp/prettier-vscode/issues/29#issuecomment-280619152) on how to implement global resolution.~~ *global resolution postponed*