### PR TITLE
Require prettier to be explicitly installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 All notable changes to the "prettier-vscode" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
 ## [Unreleased]
+- Local prettier has to be *explicitely* installed (dependencies or devDependencies)
+
+## [0.11.0]
 - Resolve 'prettier' against formatted file. Nearest upward *node_modules/prettier*
 
 ## [0.10.0]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ If true, puts the `>` of a multi-line jsx element at the end of the last line in
 #### parser (default: 'babylon')
 Which parser to use. Valid options are 'flow' and 'babylon'
 
+### Prettier resolution
+This extension will use prettier from your project's local dependencies.
+
 ### Contribute
 
 This is my first Visual Studio Extension so I probably made some terrible choices. Feel free to open issue or PRs!

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "0.22.0"
+    "prettier": "0.22.0",
+    "read-pkg-up": "2.0.0"
   }
 }

--- a/src/requirePrettier.ts
+++ b/src/requirePrettier.ts
@@ -30,7 +30,9 @@ function requirePrettier(fspath: string): Prettier {
     const prettierPath = readFromPkg(fspath);
     if (prettierPath !== void 0) {
         try {
-            return require(prettierPath);
+            const resolvedPrettier: Prettier = require(prettierPath);
+            console.log("Using prettier", resolvedPrettier.version, "from", prettierPath);
+            return resolvedPrettier;
         } catch (e) {
             console.error(e.message);
         }

--- a/src/requirePrettier.ts
+++ b/src/requirePrettier.ts
@@ -29,13 +29,9 @@ function readFromPkg(fspath: string): string | undefined {
 function requirePrettier(fspath: string): Prettier {
     const prettierPath = readFromPkg(fspath);
     if (prettierPath !== void 0) {
-        try {
-            const resolvedPrettier: Prettier = require(prettierPath);
-            console.log("Using prettier", resolvedPrettier.version, "from", prettierPath);
-            return resolvedPrettier;
-        } catch (e) {
-            console.error(e.message);
-        }
+        const resolvedPrettier: Prettier = require(prettierPath);
+        console.log("Using prettier", resolvedPrettier.version, "from", prettierPath);
+        return resolvedPrettier;
     }
     return require('prettier');
 }

--- a/src/requirePrettier.ts
+++ b/src/requirePrettier.ts
@@ -1,24 +1,39 @@
 const path = require('path');
-const Module = require('module');
+const readPkgUp = require('read-pkg-up');
 
 interface Prettier {
     format: (string, PrettierConfig?) => string;
     readonly version: string;
 }
+/**
+ * Recursively search for a package.json upwards containing prettier 
+ * as a dependency or devDependency.
+ * @param {string} fspath file system path to start searching from
+ * @returns {string} resolved path to prettier
+ */
+function readFromPkg(fspath: string): string | undefined {
+    const res = readPkgUp.sync({ cwd: fspath })
+    if (res.pkg && (res.pkg.dependencies.prettier || res.pkg.devDependencies.prettier)) {
+        return path.resolve(res.path, '..', 'node_modules/prettier');
+    } else if (res.path) {
+        return readFromPkg(path.resolve(path.dirname(res.path), '..'));
+    }
+}
 
 /**
- * Require 'prettier' relative to given path.
+ * Require 'prettier' explicitely installed relative to given path.
  * Fallback to packaged one if no prettier was found bottom up.
  * @param {string} fspath file system path starting point to resolve 'prettier'
  * @returns {Prettier} prettier
  */
 function requirePrettier(fspath: string): Prettier {
-    const fileModule = new Module(fspath);
-    fileModule.paths = Module._nodeModulePaths(path.join(fspath, '..'));
-    try {
-        return fileModule.require('prettier');
-    } catch (e) {
-        // No local prettier found
+    const prettierPath = readFromPkg(fspath);
+    if (prettierPath !== void 0) {
+        try {
+            return require(prettierPath);
+        } catch (e) {
+            console.error(e.message);
+        }
     }
     return require('prettier');
 }


### PR DESCRIPTION
Changing prettier's resolution algorithm.
Instead of searching for a `node_modules/prettier` search recursively for a package.json with prettier as dependency or devDependency and then try to load it from `node_modules`.

Pulls in a new package [read-pkg-up](https://www.npmjs.com/package/read-pkg-up)

fixes #65 
fixes #59 