### PR TITLE
Implement vue support

### DIFF
--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -107,9 +107,28 @@ class PrettierEditProvider implements
         token: CancellationToken
     ): TextEdit[] {
         try {
+            const text = document.getText();
+            
+            if (document.fileName.slice(0, -4) === '.vue') {
+                const start = text.indexOf('<script>');
+                if (start !== -1) {
+                    const end = text.indexOf('</script>');
+                    if (end !== -1) {
+                        const startPos = document.positionAt(start + 8); // 8 = length of '<script>'
+                        const endPos = document.positionAt(end - 1); // -1 = character before '</script>'
+                        const range = new Range(startPos, endPos);
+
+                        return [TextEdit.replace(
+                            range,
+                            format(document.getText(range), document.fileName)
+                        )];                        
+                    }
+                }
+            }
+            
             return [TextEdit.replace(
                 fullDocumentRange(document),
-                format(document.getText(), document.fileName)
+                format(text, document.fileName)
             )];
         } catch (e) {
             let errorPosition;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import EditProvider from './PrettierEditProvider';
 
 import { PrettierVSCodeConfig } from './types.d';
 
-const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact', 'jsx'];
+const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact', 'jsx', 'vue'];
 
 function checkConfig() {
     const config: PrettierVSCodeConfig = workspace.getConfiguration('prettier') as any;


### PR DESCRIPTION
@CiGit,

This is mostly a proof-of-concept (as I don't have the extension dev env in my workstation), so it's also untested.

I didn't a find a way to avoid a direct check for a vue extension.

So this gets the document text, looks for the offsets of script tags, then converts them to a Range that will be processed by prettier.

Let me know what you think.

Related to #87