### PR TITLE
Add TypeScript and CSS support and run code through prettier!

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,11 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
+
+    "prettier.tabWidth": 4,
+    "prettier.singleQuote": true,
+    "prettier.trailingComma": "es5",
+    "prettier.runOnTypeScript": true,
+
     "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
 }

--- a/package.json
+++ b/package.json
@@ -89,12 +89,10 @@
           "type": "string",
           "enum": [
             "babylon",
-            "flow",
-            "typescript",
-            "postcss"
+            "flow"
           ],
           "default": "babylon",
-          "description": "Which parser to use. \"typescript\" and \"postcss\" are supported in prettier 1.4.0"
+          "description": "Override the parser. You shouldn't have to change this setting."
         },
         "prettier.semi": {
           "type": "boolean",
@@ -124,7 +122,7 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
-    "prettier": "1.4.0",
+    "prettier": "1.4.1",
     "prettier-eslint": "6.2.3",
     "read-pkg-up": "2.0.0",
     "semver": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "activationEvents": [
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
     "onLanguage:jsx"
   ],
   "main": "./out/src/extension",
@@ -109,7 +111,7 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
-    "typescript": "^2.0.3",
+    "typescript": "~2.3.2",
     "vscode": "^1.0.0",
     "mocha": "^2.3.3",
     "@types/node": "^6.0.40",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
-    "onLanguage:jsx"
+    "onLanguage:jsx",
+    "onLanguage:css",
+    "onLanguage:less",
+    "onLanguage:scss"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -86,10 +89,12 @@
           "type": "string",
           "enum": [
             "babylon",
-            "flow"
+            "flow",
+            "typescript",
+            "postcss"
           ],
           "default": "babylon",
-          "description": "Which parser to use. Valid options are 'flow' and 'babylon'"
+          "description": "Which parser to use. \"typescript\" and \"postcss\" are supported in prettier 1.4.0"
         },
         "prettier.semi": {
           "type": "boolean",
@@ -111,15 +116,17 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
-    "typescript": "~2.3.2",
-    "vscode": "^1.0.0",
-    "mocha": "^2.3.3",
+    "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.40",
-    "@types/mocha": "^2.2.32"
+    "@types/semver": "^5.3.31",
+    "mocha": "^2.3.3",
+    "typescript": "~2.3.2",
+    "vscode": "^1.0.0"
   },
   "dependencies": {
     "prettier": "1.4.0",
     "prettier-eslint": "6.2.3",
-    "read-pkg-up": "2.0.0"
+    "read-pkg-up": "2.0.0",
+    "semver": "^5.3.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,34 +4,52 @@ import {
     DocumentSelector,
     window,
     workspace
-} from 'vscode';
-import EditProvider from './PrettierEditProvider';
+} from "vscode";
+import EditProvider from "./PrettierEditProvider";
 
-import { PrettierVSCodeConfig } from './types.d';
+import { PrettierVSCodeConfig } from "./types.d";
 
-const VALID_LANG: DocumentSelector = ['javascript', 'javascriptreact', 'jsx'];
+const VALID_JS_LANG = ["javascript", "javascriptreact", "jsx"];
 
-function checkConfig() {
-    const config: PrettierVSCodeConfig = workspace.getConfiguration('prettier') as any;
+const VALID_TS_LANG = ["typescript", "typescriptreact"];
+
+function checkConfig(): PrettierVSCodeConfig {
+    const config: PrettierVSCodeConfig = workspace.getConfiguration(
+        "prettier"
+    ) as any;
     if (config.useFlowParser) {
-        window.showWarningMessage("Option 'useFlowParser' has been deprecated. Use 'parser: \"flow\"' instead.");
+        window.showWarningMessage(
+            "Option 'useFlowParser' has been deprecated. " +
+                "Use 'parser: \"flow\"' instead."
+        );
     }
-    if (typeof config.trailingComma === 'boolean') {
-        window.showWarningMessage("Option 'trailingComma' as a boolean value has been deprecated. Use 'none', 'es5' or 'all' instead.");
+    if (typeof config.trailingComma === "boolean") {
+        window.showWarningMessage(
+            "Option 'trailingComma' as a boolean value has been deprecated. " +
+                "Use 'none', 'es5' or 'all' instead."
+        );
     }
+    return config;
 }
+
 export function activate(context: ExtensionContext) {
     const editProvider = new EditProvider();
-    checkConfig();
+    const config = checkConfig();
+    const languageSelector = config.runOnTypeScript
+        ? [...VALID_JS_LANG, ...VALID_TS_LANG]
+        : VALID_JS_LANG;
 
     context.subscriptions.push(
-        languages.registerDocumentRangeFormattingEditProvider(VALID_LANG, editProvider)
-    );
-    context.subscriptions.push(
-        languages.registerDocumentFormattingEditProvider(VALID_LANG, editProvider)
+        languages.registerDocumentRangeFormattingEditProvider(
+            languageSelector,
+            editProvider
+        ),
+        languages.registerDocumentFormattingEditProvider(
+            languageSelector,
+            editProvider
+        )
     );
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {
-}
+export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { PrettierVSCodeConfig } from './types.d';
 const VALID_LANG = {
     js: ['javascript', 'javascriptreact', 'jsx'],
     ts: ['typescript', 'typescriptreact'],
+    css: ['css', 'less', 'sass'],
 };
 
 function checkConfig(): PrettierVSCodeConfig {
@@ -36,9 +37,11 @@ function checkConfig(): PrettierVSCodeConfig {
 export function activate(context: ExtensionContext) {
     const editProvider = new EditProvider();
     const config = checkConfig();
-    const languageSelector = config && config.runOnTypeScript
-        ? [...VALID_LANG.js, ...VALID_LANG.ts]
-        : VALID_LANG.js;
+    const languageSelector = [
+        ...VALID_LANG.js,
+        ...VALID_LANG.ts,
+        ...VALID_LANG.css,
+    ];
 
     context.subscriptions.push(
         languages.registerDocumentRangeFormattingEditProvider(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,27 +3,28 @@ import {
     ExtensionContext,
     DocumentSelector,
     window,
-    workspace
-} from "vscode";
-import EditProvider from "./PrettierEditProvider";
+    workspace,
+} from 'vscode';
+import EditProvider from './PrettierEditProvider';
 
-import { PrettierVSCodeConfig } from "./types.d";
+import { PrettierVSCodeConfig } from './types.d';
 
-const VALID_JS_LANG = ["javascript", "javascriptreact", "jsx"];
-
-const VALID_TS_LANG = ["typescript", "typescriptreact"];
+const VALID_LANG = {
+    js: ['javascript', 'javascriptreact', 'jsx'],
+    ts: ['typescript', 'typescriptreact'],
+};
 
 function checkConfig(): PrettierVSCodeConfig {
     const config: PrettierVSCodeConfig = workspace.getConfiguration(
-        "prettier"
+        'prettier'
     ) as any;
     if (config.useFlowParser) {
         window.showWarningMessage(
             "Option 'useFlowParser' has been deprecated. " +
-                "Use 'parser: \"flow\"' instead."
+                'Use \'parser: "flow"\' instead.'
         );
     }
-    if (typeof config.trailingComma === "boolean") {
+    if (typeof config.trailingComma === 'boolean') {
         window.showWarningMessage(
             "Option 'trailingComma' as a boolean value has been deprecated. " +
                 "Use 'none', 'es5' or 'all' instead."
@@ -35,9 +36,9 @@ function checkConfig(): PrettierVSCodeConfig {
 export function activate(context: ExtensionContext) {
     const editProvider = new EditProvider();
     const config = checkConfig();
-    const languageSelector = config.runOnTypeScript
-        ? [...VALID_JS_LANG, ...VALID_TS_LANG]
-        : VALID_JS_LANG;
+    const languageSelector = config && config.runOnTypeScript
+        ? [...VALID_LANG.js, ...VALID_LANG.ts]
+        : VALID_LANG.js;
 
     context.subscriptions.push(
         languages.registerDocumentRangeFormattingEditProvider(

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -1,10 +1,9 @@
-import { Prettier, PrettierEslintFormat } from './types.d';
-const path = require('path');
-const readPkgUp = require('read-pkg-up');
-
+import { Prettier, PrettierEslintFormat } from "./types.d";
+const path = require("path");
+const readPkgUp = require("read-pkg-up");
 
 /**
- * Recursively search for a package.json upwards containing given package 
+ * Recursively search for a package.json upwards containing given package
  * as a dependency or devDependency.
  * @param {string} fspath file system path to start searching from
  * @param {string} pkgName package's name to search for
@@ -12,13 +11,14 @@ const readPkgUp = require('read-pkg-up');
  */
 function findPkg(fspath: string, pkgName: string): string | undefined {
     const res = readPkgUp.sync({ cwd: fspath, normalize: false });
-    if (res.pkg && (
-        (res.pkg.dependencies && res.pkg.dependencies[pkgName])
-        || (res.pkg.devDependencies && res.pkg.devDependencies[pkgName])
-    )) {
-        return path.resolve(res.path, '..', 'node_modules/', pkgName);
+    if (
+        res.pkg &&
+        ((res.pkg.dependencies && res.pkg.dependencies[pkgName]) ||
+            (res.pkg.devDependencies && res.pkg.devDependencies[pkgName]))
+    ) {
+        return path.resolve(res.path, "..", "node_modules/", pkgName);
     } else if (res.path) {
-        return findPkg(path.resolve(path.dirname(res.path), '..'), pkgName);
+        return findPkg(path.resolve(path.dirname(res.path), ".."), pkgName);
     }
     return;
 }

--- a/src/requirePkg.ts
+++ b/src/requirePkg.ts
@@ -1,6 +1,6 @@
-import { Prettier, PrettierEslintFormat } from "./types.d";
-const path = require("path");
-const readPkgUp = require("read-pkg-up");
+import { Prettier, PrettierEslintFormat } from './types.d';
+const path = require('path');
+const readPkgUp = require('read-pkg-up');
 
 /**
  * Recursively search for a package.json upwards containing given package
@@ -16,9 +16,9 @@ function findPkg(fspath: string, pkgName: string): string | undefined {
         ((res.pkg.dependencies && res.pkg.dependencies[pkgName]) ||
             (res.pkg.devDependencies && res.pkg.devDependencies[pkgName]))
     ) {
-        return path.resolve(res.path, "..", "node_modules/", pkgName);
+        return path.resolve(res.path, '..', 'node_modules/', pkgName);
     } else if (res.path) {
-        return findPkg(path.resolve(path.dirname(res.path), ".."), pkgName);
+        return findPkg(path.resolve(path.dirname(res.path), '..'), pkgName);
     }
     return;
 }
@@ -34,7 +34,7 @@ function requireLocalPkg(fspath: string, pkgName: string): any {
     const modulePath = findPkg(fspath, pkgName);
     if (modulePath !== void 0) {
         const resolved = require(modulePath);
-        console.log("Using ", pkgName, resolved.version, "from", modulePath);
+        console.log('Using ', pkgName, resolved.version, 'from', modulePath);
         return resolved;
     }
     return require(pkgName);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,9 @@
-type ParserOption = 'babylon' | 'flow';
-type TrailingCommaOption = 'none' | 'es5' | 'all' | boolean; /* deprecated boolean*/
+type ParserOption = "babylon" | "flow" | "typescript";
+type TrailingCommaOption =
+    | "none"
+    | "es5"
+    | "all"
+    | boolean; /* deprecated boolean*/
 /**
  * Prettier configuration
  */
@@ -24,6 +28,11 @@ interface ExtensionConfig {
      * Other settings will only be fallbacks in case they could not be inferred from eslint rules.
      */
     eslintIntegration: boolean;
+
+    /**
+     * Enable (experimental) TypeScript support.
+     */
+    runOnTypeScript: boolean;
 }
 /**
  * Configuration for prettier-vscode
@@ -33,9 +42,9 @@ export interface Prettier {
     format: (string, PrettierConfig?) => string;
     readonly version: string;
 }
-type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace'
+type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 interface PrettierEslintOptions {
-    /** 
+    /**
      * The path of the file being formatted
      * can be used in lieu of `eslintConfig` (eslint will be used to find the
      * relevant config for the file). Will also be used to load the `text` if
@@ -79,7 +88,7 @@ interface PrettierEslintOptions {
 }
 /**
  * Format javascript code with prettier-eslint.
- * 
+ *
  * @param {PrettierEslintOptions} options - Option bag for prettier-eslint.
  * @returns {string} the formatted code.
  */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,9 +1,10 @@
-type ParserOption = "babylon" | "flow" | "typescript";
+type ParserOption = 'babylon' | 'flow' | 'typescript';
 type TrailingCommaOption =
-    | "none"
-    | "es5"
-    | "all"
+    | 'none'
+    | 'es5'
+    | 'all'
     | boolean; /* deprecated boolean*/
+
 /**
  * Prettier configuration
  */
@@ -34,6 +35,7 @@ interface ExtensionConfig {
      */
     runOnTypeScript: boolean;
 }
+
 /**
  * Configuration for prettier-vscode
  */
@@ -42,7 +44,7 @@ export interface Prettier {
     format: (string, PrettierConfig?) => string;
     readonly version: string;
 }
-type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
 interface PrettierEslintOptions {
     /**
      * The path of the file being formatted
@@ -86,6 +88,7 @@ interface PrettierEslintOptions {
      */
     prettierLast?: boolean;
 }
+
 /**
  * Format javascript code with prettier-eslint.
  *

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-type ParserOption = 'babylon' | 'flow' | 'typescript';
+type ParserOption = 'babylon' | 'flow' | 'postcss' | 'typescript';
 type TrailingCommaOption =
     | 'none'
     | 'es5'
@@ -20,6 +20,7 @@ export interface PrettierConfig {
     semi?: boolean;
     useTabs?: boolean;
 }
+
 /**
  * prettier-vscode specific configuration
  */
@@ -29,11 +30,6 @@ interface ExtensionConfig {
      * Other settings will only be fallbacks in case they could not be inferred from eslint rules.
      */
     eslintIntegration: boolean;
-
-    /**
-     * Enable (experimental) TypeScript support.
-     */
-    runOnTypeScript: boolean;
 }
 
 /**


### PR DESCRIPTION
So as you may be aware, we're working pretty hard on on adding TypeScript support to prettier (prettier/prettier#13 and prettier/prettier#1480).

I thought now that we're parsing _almost_ everything, that it would be a good time to add some experimental support to this extension.

I've adding a new config option, `"prettier.runOnTypeScript"` that is not documented in `package.json`, so no-one will find it by accident. 

When the setting is enabled, the extension will also provide edits to TypeScript and TypeScript React files.

I then used this extension to run prettier on this extension's source code ![yodawg](https://cdn.frankerfacez.com/emoticon/43605/1), with default settings plus `"prettier.tabWidth": 4`. I committed most of the changes.

Note that for this to work you need to install prettier@master from github, and install the correct `typescript-eslint-parser` commit from prettier's package.json.

When full TypeScript support is released in prettier, the only changed required are:

- [x] Remove the `"prettier.runOnTypeScript"` setting
- [x] Turn on TypeScript support if the installed version of prettier supports TypeScript (by version number).