### PR TITLE
Update Prettier to v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "1.3.1",
+    "prettier": "1.4.0",
     "prettier-eslint": "6.2.3",
     "read-pkg-up": "2.0.0"
   }


### PR DESCRIPTION
Prettier v1.4.0 brings CSS support so it will be good to upgrade to that ASAP. [See Release Notes](https://github.com/prettier/prettier/releases/tag/1.4.0).