### PR TITLE
Preserve indentation when formatting selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "prettier": "1.3.1",
+    "prettier": "1.4.0",
     "prettier-eslint": "6.2.3",
     "read-pkg-up": "2.0.0"
   }


### PR DESCRIPTION
This fixes https://github.com/esbenp/prettier-vscode/issues/109 by using
the new `rangeStart` and `rangeEnd` options in Prettier v1.4.0 (see here
for details: https://github.com/prettier/prettier/pull/1609)