### PR TITLE
language selector option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
     "prettier.tabWidth": 4,
     "prettier.singleQuote": true,
     "prettier.trailingComma": "es5",
-    "prettier.runOnTypeScript": true,
 
     "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
 }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ or only at the beginning of lines that may introduce ASI failures (semi: false)
 #### prettier.useTabs (default: false)
 If true, indent lines with tabs
 
+#### prettier.javascriptEnable (default: ["javascript", "javascriptreact"])
+Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
+Use parser `babylon` or `flow` depending on `prettier.parser` for given language ids.
+Use with care.
+
+#### prettier.typescriptEnable (default: ["typescript", "typescriptreact"])
+Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
+Use parser `typescript` for given language ids.
+Use with care.
+
+#### prettier.cssEnable (default: ["css", "less", "sass"])
+Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
+Use parser `postcss` for given language ids.
+Use with care.
+
 ### Prettier resolution
 This extension will use prettier from your project's local dependencies. Should prettier not be installed locally with your project's dependencies, a copy will be bundled with the extension. 
 

--- a/package.json
+++ b/package.json
@@ -25,14 +25,7 @@
     "Formatters"
   ],
   "activationEvents": [
-    "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onLanguage:typescript",
-    "onLanguage:typescriptreact",
-    "onLanguage:jsx",
-    "onLanguage:css",
-    "onLanguage:less",
-    "onLanguage:scss"
+    "*"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -103,6 +96,71 @@
           "type": "boolean",
           "default": false,
           "description": "Indent lines with tabs"
+        },
+        "prettier.javascriptEnable": {
+          "description": "Advanced feature. Enable and use 'prettier.parser' parser for those language ids. Restart required",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "javascript",
+                  "javascriptreact"
+                ]
+              }
+            ]
+          },
+          "default": [
+            "javascript",
+            "javascriptreact"
+          ]
+        },
+        "prettier.typescriptEnable": {
+          "description": "Advanced feature. Enable and use typescript parser for those language ids. Restart required",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "typescript",
+                  "typescriptreact"
+                ]
+              }
+            ]
+          },
+          "default": [
+            "typescript",
+            "typescriptreact"
+          ]
+        },
+        "prettier.cssEnable": {
+          "description": "Advanced feature. Enable and use postcss parser for those language ids. Restart required",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "css",
+                  "less",
+                  "sass"
+                ]
+              }
+            ]
+          },
+          "default": [
+            "css",
+            "less",
+            "sass"
+          ]
         }
       }
     }
@@ -122,7 +180,7 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
-    "prettier": "1.4.1",
+    "prettier": "1.4.2",
     "prettier-eslint": "6.2.3",
     "read-pkg-up": "2.0.0",
     "semver": "^5.3.0"

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -47,15 +47,11 @@ function format(
         // unset config
         parser = config.useFlowParser ? 'flow' : 'babylon';
     }
-    if (languageId === 'typescript' || languageId === 'typescriptreact') {
+    if (config.typescriptEnable.includes(languageId)) {
         parser = 'typescript';
         isNonJsParser = true;
     }
-    if (
-        languageId === 'css' ||
-        languageId === 'less' ||
-        languageId === 'scss'
-    ) {
+    if (config.cssEnable.includes(languageId)) {
         parser = 'postcss';
         isNonJsParser = true;
     }
@@ -94,7 +90,7 @@ function format(
     }
     const prettier = requireLocalPkg(fileName, 'prettier') as Prettier;
     if (isNonJsParser && semver.lt(prettier.version, '1.4.0-beta')) {
-        const bundledPrettier = require('prettier');
+        const bundledPrettier = require('prettier') as Prettier;
         window.showWarningMessage(
             `prettier@${prettier.version} doesn't suport ${languageId}. ` +
                 `Falling back to bundled prettier@${bundledPrettier.version}.`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,12 +9,6 @@ import EditProvider from './PrettierEditProvider';
 
 import { PrettierVSCodeConfig } from './types.d';
 
-const VALID_LANG = {
-    js: ['javascript', 'javascriptreact', 'jsx'],
-    ts: ['typescript', 'typescriptreact'],
-    css: ['css', 'less', 'sass'],
-};
-
 function checkConfig(): PrettierVSCodeConfig {
     const config: PrettierVSCodeConfig = workspace.getConfiguration(
         'prettier'
@@ -38,9 +32,9 @@ export function activate(context: ExtensionContext) {
     const editProvider = new EditProvider();
     const config = checkConfig();
     const languageSelector = [
-        ...VALID_LANG.js,
-        ...VALID_LANG.ts,
-        ...VALID_LANG.css,
+        ...config.javascriptEnable,
+        ...config.typescriptEnable,
+        ...config.cssEnable,
     ];
 
     context.subscriptions.push(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,7 +20,11 @@ export interface PrettierConfig {
     semi?: boolean;
     useTabs?: boolean;
 }
-
+interface Language {
+    javascript: ('javascript' | 'javascriptreact' | string)[];
+    typescript: ('typescript' | 'typescriptreact' | string)[];
+    css: ('css' | 'less' | 'sass' | string)[];
+}
 /**
  * prettier-vscode specific configuration
  */
@@ -30,6 +34,18 @@ interface ExtensionConfig {
      * Other settings will only be fallbacks in case they could not be inferred from eslint rules.
      */
     eslintIntegration: boolean;
+    /**
+     * Language ids to run javascript prettier on.
+     */
+    javascriptEnable: ('javascript' | 'javascriptreact' | string)[];
+    /**
+     * Language ids to run typescript prettier on.
+     */
+    typescriptEnable: ('typescript' | 'typescriptreact' | string)[];
+    /**
+     * Language ids to run postcss prettier on.
+     */
+    cssEnable: ('css' | 'less' | 'sass' | string)[];
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es2016"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
This is the less worst of my ideas to resolve #114 and resolve #115 and possible others like adding 'jsx' to our VALID_LANG.

This PR provides 3 new options:
`javascriptEnable: string[]`
`typescriptEnable: string[]`
`cssEnable: string[]`
Those 3 options are a mapping between a parser and language ids.
This allows to add other extensions language ids to be prettified.
This also allows to prevent prettier from running on language ids.

#### Examples
- Use an other formater for CSS and relatives (disable prettier for those file types):
`cssEnable:[]`
- Add `jsx` to javascript parser:
`javascriptEnable:['javascript', 'javascriptreact', 'jsx']`

Break: I removed `jsx` language id by default. I've let only language ids provided by vscode.