### PR TITLE
Fix css format, change sass to scss for cssEnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Advanced feature. Use this to opt in / out prettier on various language ids. Res
 Use parser `typescript` for given language ids.
 Use with care.
 
-#### prettier.cssEnable (default: ["css", "less", "sass"])
+#### prettier.cssEnable (default: ["css", "less", "scss"])
 Advanced feature. Use this to opt in / out prettier on various language ids. Restart required.
 Use parser `postcss` for given language ids.
 Use with care.

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
                 "enum": [
                   "css",
                   "less",
-                  "sass"
+                  "scss"
                 ]
               }
             ]
@@ -159,7 +159,7 @@
           "default": [
             "css",
             "less",
-            "sass"
+            "scss"
           ]
         }
       }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,7 +23,7 @@ export interface PrettierConfig {
 interface Language {
     javascript: ('javascript' | 'javascriptreact' | string)[];
     typescript: ('typescript' | 'typescriptreact' | string)[];
-    css: ('css' | 'less' | 'sass' | string)[];
+    css: ('css' | 'less' | 'scss' | string)[];
 }
 /**
  * prettier-vscode specific configuration
@@ -45,7 +45,7 @@ interface ExtensionConfig {
     /**
      * Language ids to run postcss prettier on.
      */
-    cssEnable: ('css' | 'less' | 'sass' | string)[];
+    cssEnable: ('css' | 'less' | 'scss' | string)[];
 }
 
 /**


### PR DESCRIPTION
Prettier does not support sass formatting at this time, scss is the
correct option and allows prettier to work correctly for all styles.

Fixes #117.