### PR TITLE
Update package.json for new parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
           "type": "string",
           "enum": [
             "babylon",
-            "flow"
+            "flow",
+            "typescript",
+            "postcss"
           ],
           "default": "babylon",
           "description": "Override the parser. You shouldn't have to change this setting."


### PR DESCRIPTION
Updates from the CLI:

```
 ~/d/p/a/i/emission $  yarn prettier -- --help

Usage: prettier [opts] [filename ...]

Available options:
  --write                  Edit the file in-place. (Beware!)
  --list-different or -l   Print filenames of files that are different from Prettier formatting.
  --stdin                  Read input from stdin.
  --stdin-filepath         Path to the file used to read from stdin.
  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.
  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.
  --use-tabs               Indent lines with tabs instead of spaces.
  --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
  --single-quote           Use single quotes instead of double quotes.
  --no-bracket-spacing     Do not print spaces between brackets.
  --jsx-bracket-same-line  Put > on the last line instead of at a new line.
  --trailing-comma <none|es5|all>
                           Print trailing commas wherever possible. Defaults to none.
  --parser <flow|babylon|typescript|postcss>
                           Specify which parse to use. Defaults to babylon.
```