### PR TITLE
Improve error handling using statusbar item & output channel

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 - [David Burrows](https://github.com/dburrows)
 - [Jon Wolfe](https://github.com/JonathanWolfe)
 - [Laurence Rowe](https://github.com/lrowe)
+- [Robin Malfait](https://github.com/RobinMalfait)

--- a/src/PrettierEditProvider.ts
+++ b/src/PrettierEditProvider.ts
@@ -12,6 +12,8 @@ import {
     Position,
 } from 'vscode';
 
+import { safeExecution, addToOutput } from './errorHandler';
+import { onWorkspaceRootChange } from './utils';
 import { requireLocalPkg } from './requirePkg';
 import * as semver from 'semver';
 
@@ -23,7 +25,8 @@ import {
     ParserOption,
 } from './types.d';
 
-type ShowAction = 'Show';
+let errorShown: Boolean = false;
+
 /**
  * Various parser appearance
  */
@@ -35,6 +38,14 @@ const PARSER_SINCE = {
     json: '1.5.0',
     graphql: '1.5.0',
 };
+
+/**
+ * Mark the error as not show, when changing workspaces
+ */
+onWorkspaceRootChange(() => {
+    errorShown = false;
+});
+
 /**
  * Check if the given parser exists in a prettier module.
  * @param parser parser to test
@@ -44,6 +55,7 @@ const PARSER_SINCE = {
 function parserExists(parser: ParserOption, prettier: Prettier) {
     return semver.gte(prettier.version, PARSER_SINCE[parser]);
 }
+
 /**
  * Format the given text with user's configuration.
  * @param text Text to format
@@ -58,6 +70,7 @@ function format(
     const config: PrettierVSCodeConfig = workspace.getConfiguration(
         'prettier'
     ) as any;
+
     /*
     handle trailingComma changes boolean -> string
     */
@@ -110,23 +123,47 @@ function format(
     );
 
     if (config.eslintIntegration && !isNonJsParser) {
-        const prettierEslint = require('prettier-eslint') as PrettierEslintFormat;
-        return prettierEslint({
+        return safeExecution(
+            () => {
+                const prettierEslint = require('prettier-eslint') as PrettierEslintFormat;
+                return prettierEslint({
+                    text,
+                    filePath: fileName,
+                    fallbackPrettierOptions: prettierOptions,
+                });
+            },
             text,
-            filePath: fileName,
-            fallbackPrettierOptions: prettierOptions,
-        });
+            fileName
+        );
     }
     const prettier = requireLocalPkg(fileName, 'prettier') as Prettier;
     if (isNonJsParser && !parserExists(parser, prettier)) {
-        const bundledPrettier = require('prettier') as Prettier;
-        window.showWarningMessage(
-            `prettier@${prettier.version} doesn't support ${languageId}. ` +
-                `Falling back to bundled prettier@${bundledPrettier.version}.`
+        return safeExecution(
+            () => {
+                const bundledPrettier = require('prettier') as Prettier;
+                const warningMessage =
+                    `prettier@${prettier.version} doesn't support ${languageId}. ` +
+                    `Falling back to bundled prettier@${bundledPrettier.version}.`;
+
+                addToOutput(warningMessage);
+
+                if (errorShown === false) {
+                    window.showWarningMessage(warningMessage);
+                    errorShown = true;
+                }
+
+                return bundledPrettier.format(text, prettierOptions);
+            },
+            text,
+            fileName
         );
-        return bundledPrettier.format(text, prettierOptions);
     }
-    return prettier.format(text, prettierOptions);
+
+    return safeExecution(
+        () => prettier.format(text, prettierOptions),
+        text,
+        fileName
+    );
 }
 
 function fullDocumentRange(document: TextDocument): Range {
@@ -143,90 +180,28 @@ class PrettierEditProvider
         options: FormattingOptions,
         token: CancellationToken
     ): TextEdit[] {
-        try {
-            return [
-                TextEdit.replace(
-                    fullDocumentRange(document),
-                    format(document.getText(), document, {
-                        rangeStart: document.offsetAt(range.start),
-                        rangeEnd: document.offsetAt(range.end),
-                    })
-                ),
-            ];
-        } catch (e) {
-            let errorPosition;
-            if (e.loc) {
-                let charPos = e.loc.column;
-                if (e.loc.line === 1) {
-                    // start selection range
-                    charPos = range.start.character + e.loc.column;
-                }
-                errorPosition = new Position(
-                    e.loc.line - 1 + range.start.line,
-                    charPos
-                );
-            }
-            handleError(document, e.message, errorPosition);
-        }
+        return [
+            TextEdit.replace(
+                fullDocumentRange(document),
+                format(document.getText(), document, {
+                    rangeStart: document.offsetAt(range.start),
+                    rangeEnd: document.offsetAt(range.end),
+                })
+            ),
+        ];
     }
     provideDocumentFormattingEdits(
         document: TextDocument,
         options: FormattingOptions,
         token: CancellationToken
     ): TextEdit[] {
-        try {
-            return [
-                TextEdit.replace(
-                    fullDocumentRange(document),
-                    format(document.getText(), document, {})
-                ),
-            ];
-        } catch (e) {
-            let errorPosition;
-            if (e.loc) {
-                errorPosition = new Position(e.loc.line - 1, e.loc.column);
-            }
-            handleError(document, e.message, errorPosition);
-        }
+        return [
+            TextEdit.replace(
+                fullDocumentRange(document),
+                format(document.getText(), document, {})
+            ),
+        ];
     }
 }
-/**
- * Handle errors for a given text document.
- * Steps:
- *  - Show the error message.
- *  - Scroll to the error position in given document if asked for it.
- *
- * @param document Document which raised the error
- * @param message Error message
- * @param errorPosition Position where the error occured. Relative to document.
- */
-function handleError(
-    document: TextDocument,
-    message: string,
-    errorPosition: Position
-) {
-    if (errorPosition) {
-        window
-            .showErrorMessage(message, 'Show')
-            .then(function onAction(action?: ShowAction) {
-                if (action === 'Show') {
-                    const rangeError = new Range(errorPosition, errorPosition);
-                    /*
-                    Show text document which has errored.
-                    Format on save case. (save all)
-                    */
-                    window.showTextDocument(document).then(editor => {
-                        // move cursor to error position and show it.
-                        editor.selection = new Selection(
-                            rangeError.start,
-                            rangeError.end
-                        );
-                        editor.revealRange(rangeError);
-                    });
-                }
-            });
-    } else {
-        window.showErrorMessage(message);
-    }
-}
+
 export default PrettierEditProvider;

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -1,0 +1,113 @@
+import {
+    Disposable,
+    StatusBarItem,
+    OutputChannel,
+    commands,
+    window,
+} from 'vscode';
+
+import { onWorkspaceRootChange } from './utils';
+
+let statusBarItem: StatusBarItem;
+let outputChannel: OutputChannel;
+let outputChannelOpen: Boolean = false;
+
+/**
+ * Mark the outputChannelOpen as false when changing workspaces
+ */
+onWorkspaceRootChange(() => {
+    outputChannelOpen = false;
+});
+
+/**
+ * Update the statusBarItem message and show the statusBarItem
+ * 
+ * @param message The message to put inside the statusBarItem
+ */
+function updateStatusBar(message: string): void {
+    statusBarItem.text = message;
+    statusBarItem.command = 'prettier.open-output';
+    statusBarItem.show();
+}
+
+/**
+ * Adds the filepath to the error message
+ *
+ * @param msg The original error message
+ * @param fileName The path to the file
+ * @returns {string} enhanced message with the filename
+ */
+function addFilePath(msg: string, fileName: string): string {
+    const lines = msg.split('\n');
+    if (lines.length > 0) {
+        lines[0] = lines[0].replace(/(\d*):(\d*)/g, `${fileName}:$1:$2`);
+        return lines.join('\n');
+    }
+
+    return msg;
+}
+/**
+ * Append messages to the output channel and format it with a title
+ * 
+ * @param message The message to append to the output channel
+ */
+export function addToOutput(message: string): void {
+    const title = `${new Date().toLocaleString()}:`;
+
+    // Create a sort of title, to differentiate between messages
+    outputChannel.appendLine(title);
+    outputChannel.appendLine('-'.repeat(title.length));
+
+    // Append actual output
+    outputChannel.appendLine(`${message}\n`);
+
+    if (outputChannelOpen === false) {
+        outputChannel.show();
+        outputChannelOpen = true;
+    }
+}
+/**
+ * Execute a callback safely, if it doesn't work, return default and log messages.
+ * 
+ * @param cb The function to be executed, 
+ * @param defaultText The default value if execution of the cb failed
+ * @param fileName The filename of the current document
+ * @returns {string} formatted text or defaultText
+ */
+export function safeExecution(
+    cb: () => string,
+    defaultText: string,
+    fileName: string
+): string {
+    try {
+        const returnValue = cb();
+
+        updateStatusBar('Prettier: $(check)');
+
+        return returnValue;
+    } catch (err) {
+        addToOutput(addFilePath(err.message, fileName));
+        updateStatusBar('Prettier: $(x)');
+
+        return defaultText;
+    }
+}
+/**
+ * Setup the output channel and the statusBarItem.
+ * Create a command to show the output channel
+ * 
+ * @returns {Disposable} The command to open the output channel
+ */
+export function setupErrorHandler(): Disposable {
+    // Setup the statusBarItem
+    statusBarItem = window.createStatusBarItem();
+    statusBarItem.text = 'Prettier';
+    statusBarItem.show();
+
+    // Setup the outputChannel
+    outputChannel = window.createOutputChannel('Prettier');
+
+    return commands.registerCommand('prettier.open-output', () => {
+        outputChannel.show();
+    });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import {
     workspace,
 } from 'vscode';
 import EditProvider from './PrettierEditProvider';
-
+import { setupErrorHandler } from './errorHandler';
 import { PrettierVSCodeConfig } from './types.d';
 
 function checkConfig(): PrettierVSCodeConfig {
@@ -52,7 +52,8 @@ export function activate(context: ExtensionContext) {
         languages.registerDocumentFormattingEditProvider(
             languageSelector,
             editProvider
-        )
+        ),
+        setupErrorHandler()
     );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,12 @@
+import { workspace } from 'vscode';
+
+let currentRootPath: string = workspace.rootPath;
+
+export function onWorkspaceRootChange(cb: (rootPath: string) => void): void {
+    workspace.onDidChangeConfiguration(() => {
+        if (currentRootPath !== workspace.rootPath) {
+            cb(workspace.rootPath);
+            currentRootPath = workspace.rootPath;
+        }
+    });
+}


### PR DESCRIPTION
Hello!

I was the author of another [prettier extension](https://github.com/RobinMalfait/prettier-eslint-code) which I deprecated for this one.

In the package I wrote I had some nice indications if your code was prettified correctly or not.
![](http://d.rbn.nu/ORUzn.png) & ![](http://d.rbn.nu/odWW8P.png). Now I know that not everybody wants it so I added an option to enable/disable this feature.

Another thing is, the current error handling is quite annoying in my opinion, you get a popup message with an error and you can't really save the file. For example when you are editing the `settings.json` file from VSCode, you will get errors because it contains invalid JSON, the `// comments`. What this PR enables is that we execute the formatting in a save way and if an error occurs we return the defaultValue (which is the current text), this way we *can* actually edit files with invalid JSON such as `settings.json`.

Last but not least, we still want to view our errors. For this very reason I added an output channel where I write the errors when something happens. If we press the statusbar item we also open the output channel.

Errors look like this:

![](http://d.rbn.nu/QOK3Zt.png)